### PR TITLE
callbacks for leaving/entering proximity of an obstruction. hooray

### DIFF
--- a/app/lib/activist.coffee
+++ b/app/lib/activist.coffee
@@ -34,4 +34,9 @@ module.exports = class Activist
       item.onHit.bottom(item, options) if item.onHit.bottom
     item.addEventListener 'hit_any', (options) ->
       item.onHit.any(item, options) if item.onHit.any
+    item.addEventListener 'enterProximity', (options) ->
+      item.proximity.onEnter(item, options) if item.proximity
+    item.addEventListener 'leaveProximity', (options) ->
+      item.proximity.onLeave(item, options) if item.proximity
+
 

--- a/app/lib/landscape.coffee
+++ b/app/lib/landscape.coffee
@@ -3,6 +3,12 @@ module.exports = [
   src: "images/table.png"
   x: 260
   y: 400
+  # proximity:
+  #   radius: 200
+  #   onEnter: (item, options) ->
+  #     console.log "ENTERING RADIUS"
+  #   onLeave: ->
+  #     console.log "LEAVING RADIUS"
 ,
   id: "table2"
   src: "images/table.png"


### PR DESCRIPTION
Adds ability to set a `proximity` attribute on obstructions.

``` coffee
  id: "table"
  src: "images/table.png"
  x: 260
  y: 400
  proximity:
    radius: 100 # within 100 pixels of the hit area
    onEnter: (item, options) ->
      console.log "ENTERING RADIUS"
    onLeave: ->
      console.log "LEAVING RADIUS"
```
